### PR TITLE
Add benchmark for Sia.NET

### DIFF
--- a/source/Ecs.CSharp.Benchmark/Categories.cs
+++ b/source/Ecs.CSharp.Benchmark/Categories.cs
@@ -14,6 +14,7 @@
         public const string Morpeh = "Morpeh";
         public const string FlecsNet = "FlecsNet";
         public const string Fennecs = "Fennecs";
+        public const string Sia = "Sia";
 
         public const string CreateEntity = "CreateEntity";
         public const string System = "System";

--- a/source/Ecs.CSharp.Benchmark/Contexts/SiaBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/SiaBaseContext.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Sia;
+
+namespace Ecs.CSharp.Benchmark.Contexts
+{
+    internal class SiaBaseContext : IDisposable
+    {
+        public partial record struct Component1(int Value);
+
+        public partial record struct Component2(int Value);
+
+        public partial record struct Component3(int Value);
+
+        public World World { get; }
+
+        public SiaBaseContext()
+        {
+            World = new World();
+            Context<World>.Current = World;
+        }
+
+        public virtual void Dispose()
+        {
+            World.Dispose();
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Sia.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Sia.cs
@@ -1,0 +1,24 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Sia;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithOneComponent
+    {
+        [Context]
+        private readonly SiaBaseContext _sia;
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia()
+        {
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                _sia.World.CreateInArrayHost(Bundle.Create(
+                    new SiaBaseContext.Component1()
+                ));
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Sia.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Sia.cs
@@ -1,0 +1,26 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Sia;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithThreeComponents
+    {
+        [Context]
+        private readonly SiaBaseContext _sia;
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia()
+        {
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                _sia.World.CreateInArrayHost(Bundle.Create(
+                    new SiaBaseContext.Component1(),
+                    new SiaBaseContext.Component2(),
+                    new SiaBaseContext.Component3()
+                ));
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Sia.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Sia.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Sia;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithTwoComponents
+    {
+        [Context]
+        private readonly SiaBaseContext _sia;
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia()
+        {
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                _sia.World.CreateInArrayHost(Bundle.Create(
+                    new SiaBaseContext.Component1(),
+                    new SiaBaseContext.Component2()
+                ));
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -28,13 +28,15 @@
   </ItemGroup>
 
   <ItemGroup Label="Ecs">
-		<PackageReference Include="Arch" Version="1.2.7" />
+    <PackageReference Include="Arch" Version="1.2.7" />
     
     <PackageReference Include="DefaultEcs" Version="0.17.2" />
     <PackageReference Include="DefaultEcs.Analyzer" Version="0.17.0" PrivateAssets="all" />
 
     <PackageReference Include="fennecs" Version="0.1.1-beta" />
-    
+
+    <PackageReference Include="Flecs.NET.Release" Version="3.2.10" />
+
     <PackageReference Include="Friflo.Engine.ECS" Version="1.14.0" />
 
     <PackageReference Include="HypEcs" Version="1.2.1" />
@@ -50,9 +52,10 @@
 
     <PackageReference Include="Scellecs.Morpeh" Version="2023.1.0" />
 
+    <PackageReference Include="Sia" Version="1.8.9" />
+
     <PackageReference Include="Svelto.ECS" Version="3.3.2" />
     <PackageReference Include="Svelto.Common" Version="3.3.2" />
-		<PackageReference Include="Flecs.NET.Release" Version="3.2.10" />
   </ItemGroup>
   
 </Project>

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Sia.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Sia.cs
@@ -1,0 +1,66 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Sia;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithOneComponent
+    {
+        private sealed class SiaContext : SiaBaseContext
+        {
+            public Scheduler MonoThreadScheduler;
+            public Scheduler MultiThreadScheduler;
+
+            public sealed class MonoThreadUpdateSystem()
+                : SystemBase(matcher: Matchers.Of<Component1>())
+            {
+                public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
+                {
+                    query.ForSlice((ref Component1 component) => {
+                        ++component.Value;
+                    });
+                }
+            }
+
+            public sealed class MultiThreadUpdateSystem()
+                : SystemBase(matcher: Matchers.Of<Component1>())
+            {
+                public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
+                {
+                    query.ForSliceOnParallel((ref Component1 component) => {
+                        ++component.Value;
+                    });
+                }
+            }
+
+            public SiaContext(int entityCount, int entityPadding) : base()
+            {
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    World.CreateInArrayHost(Bundle.Create(new Component1()));
+                }
+
+                MonoThreadScheduler = new Scheduler();
+                SystemChain.Empty
+                    .Add<MonoThreadUpdateSystem>()
+                    .RegisterTo(World, MonoThreadScheduler);
+
+                MultiThreadScheduler = new Scheduler();
+                SystemChain.Empty
+                    .Add<MultiThreadUpdateSystem>()
+                    .RegisterTo(World, MultiThreadScheduler);
+            }
+        }
+
+        [Context]
+        private readonly SiaContext _sia;
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia_MonoThread() => _sia.MonoThreadScheduler.Tick();
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia_MultiThread() => _sia.MultiThreadScheduler.Tick();
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Sia.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Sia.cs
@@ -37,6 +37,11 @@ namespace Ecs.CSharp.Benchmark
             {
                 for (int i = 0; i < entityCount; ++i)
                 {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        World.CreateInArrayHost(Bundle.Create(0));
+                    }
+
                     World.CreateInArrayHost(Bundle.Create(new Component1()));
                 }
 

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Sia.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Sia.cs
@@ -1,0 +1,87 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Sia;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithThreeComponents
+    {
+        private sealed class SiaContext : SiaBaseContext
+        {
+            public Scheduler MonoThreadScheduler;
+            public Scheduler MultiThreadScheduler;
+
+            public sealed class MonoThreadUpdateSystem()
+                : SystemBase(matcher: Matchers.Of<Component1, Component2, Component3>())
+            {
+                public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
+                {
+                    query.ForSlice((ref Component1 c1, ref Component2 c2, ref Component3 c3) => {
+                        c1.Value += c2.Value + c3.Value;
+                    });
+                }
+            }
+
+            public sealed class MultiThreadUpdateSystem()
+                : SystemBase(matcher: Matchers.Of<Component1, Component2, Component3>())
+            {
+                public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
+                {
+                    query.ForSliceOnParallel((ref Component1 c1, ref Component2 c2, ref Component3 c3) => {
+                        c1.Value += c2.Value + c3.Value;
+                    });
+                }
+            }
+
+            public SiaContext(int entityCount, int entityPadding)
+            {
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        switch (j % 3)
+                        {
+                            case 0:
+                                World.CreateInArrayHost(Bundle.Create(new Component1()));
+                                break;
+
+                            case 1:
+                                World.CreateInArrayHost(Bundle.Create(new Component2()));
+                                break;
+
+                            case 2:
+                                World.CreateInArrayHost(Bundle.Create(new Component3()));
+                                break;
+                        }
+                    }
+
+                    World.CreateInArrayHost(Bundle.Create(
+                        new Component1(),
+                        new Component2(),
+                        new Component3()));
+                }
+
+                MonoThreadScheduler = new Scheduler();
+                SystemChain.Empty
+                    .Add<MonoThreadUpdateSystem>()
+                    .RegisterTo(World, MonoThreadScheduler);
+
+                MultiThreadScheduler = new Scheduler();
+                SystemChain.Empty
+                    .Add<MultiThreadUpdateSystem>()
+                    .RegisterTo(World, MultiThreadScheduler);
+            }
+        }
+
+        [Context]
+        private readonly SiaContext _sia;
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia_MonoThread() => _sia.MonoThreadScheduler.Tick();
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia_MultiThread() => _sia.MultiThreadScheduler.Tick();
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Sia.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Sia.cs
@@ -1,0 +1,80 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Sia;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithTwoComponents
+    {
+        private sealed class SiaContext : SiaBaseContext
+        {
+            public Scheduler MonoThreadScheduler;
+            public Scheduler MultiThreadScheduler;
+
+            public sealed class MonoThreadUpdateSystem()
+                : SystemBase(matcher: Matchers.Of<Component1, Component2>())
+            {
+                public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
+                {
+                    query.ForSlice((ref Component1 c1, ref Component2 c2) => {
+                        c1.Value += c2.Value;
+                    });
+                }
+            }
+
+            public sealed class MultiThreadUpdateSystem()
+                : SystemBase(matcher: Matchers.Of<Component1, Component2>())
+            {
+                public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
+                {
+                    query.ForSliceOnParallel((ref Component1 c1, ref Component2 c2) => {
+                        c1.Value += c2.Value;
+                    });
+                }
+            }
+
+            public SiaContext(int entityCount, int entityPadding) : base()
+            {
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        switch (j % 2)
+                        {
+                            case 0:
+                                World.CreateInArrayHost(Bundle.Create(new Component1()));
+                                break;
+
+                            case 1:
+                                World.CreateInArrayHost(Bundle.Create(new Component2()));
+                                break;
+                        }
+                    }
+
+                    World.CreateInArrayHost(Bundle.Create(new Component1(), new Component2()));
+                }
+
+                MonoThreadScheduler = new Scheduler();
+                SystemChain.Empty
+                    .Add<MonoThreadUpdateSystem>()
+                    .RegisterTo(World, MonoThreadScheduler);
+
+                MultiThreadScheduler = new Scheduler();
+                SystemChain.Empty
+                    .Add<MultiThreadUpdateSystem>()
+                    .RegisterTo(World, MultiThreadScheduler);
+            }
+        }
+
+        [Context]
+        private readonly SiaContext _sia;
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia_MonoThread() => _sia.MonoThreadScheduler.Tick();
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia_MultiThread() => _sia.MultiThreadScheduler.Tick();
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Sia.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Sia.cs
@@ -1,0 +1,91 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Sia;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithTwoComponentsMultipleComposition
+    {
+        private sealed class SiaContext : SiaBaseContext
+        {
+            public Scheduler MonoThreadScheduler;
+            public Scheduler MultiThreadScheduler;
+
+            private partial record struct Padding1();
+
+            private partial record struct Padding2();
+
+            private partial record struct Padding3();
+
+            private partial record struct Padding4();
+
+            public sealed class MonoThreadUpdateSystem()
+                : SystemBase(matcher: Matchers.Of<Component1, Component2>())
+            {
+                public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
+                {
+                    query.ForSlice((ref Component1 c1, ref Component2 c2) => {
+                        c1.Value += c2.Value;
+                    });
+                }
+            }
+
+            public sealed class MultiThreadUpdateSystem()
+                : SystemBase(matcher: Matchers.Of<Component1, Component2>())
+            {
+                public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
+                {
+                    query.ForSliceOnParallel((ref Component1 c1, ref Component2 c2) => {
+                        c1.Value += c2.Value;
+                    });
+                }
+            }
+
+            public SiaContext(int entityCount) : base()
+            {
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    switch (i % 4)
+                    {
+                        case 0:
+                            World.CreateInArrayHost(Bundle.Create(new Component1(), new Component2(), new Padding1()));;
+                            break;
+
+                        case 1:
+                            World.CreateInArrayHost(Bundle.Create(new Component1(), new Component2(), new Padding2()));
+                            break;
+
+                        case 2:
+                            World.CreateInArrayHost(Bundle.Create(new Component1(), new Component2(), new Padding3()));
+                            break;
+
+                        case 3:
+                            World.CreateInArrayHost(Bundle.Create(new Component1(), new Component2(), new Padding4()));
+                            break;
+                    }
+                }
+
+                MonoThreadScheduler = new Scheduler();
+                SystemChain.Empty
+                    .Add<MonoThreadUpdateSystem>()
+                    .RegisterTo(World, MonoThreadScheduler);
+
+                MultiThreadScheduler = new Scheduler();
+                SystemChain.Empty
+                    .Add<MultiThreadUpdateSystem>()
+                    .RegisterTo(World, MultiThreadScheduler);
+            }
+        }
+
+        [Context]
+        private readonly SiaContext _sia;
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia_MonoThread() => _sia.MonoThreadScheduler.Tick();
+
+        [BenchmarkCategory(Categories.Sia)]
+        [Benchmark]
+        public void Sia_MultiThread() => _sia.MultiThreadScheduler.Tick();
+    }
+}


### PR DESCRIPTION
I suspect an issue with my system's code is negatively impacting performance and causing the program to crash.

P.s. Here is the test results; this test is really slow :joy:.

### CreateEntity

| Method                          | EntityCount | Mean     | Error     | StdDev    | Median   | Gen0      | Gen1      | Gen2      | Allocated |
| ------------------------------- | ----------- | -------- | --------- | --------- | -------- | --------- | --------- | --------- | --------- |
| CreateEntityWithOneComponent    | 100000      | 6.726 ms | 0.1770 ms | 0.5192 ms | 6.568 ms | 1000.0000 | 1000.0000 | 1000.0000 | 8.22 MB   |
| CreateEntityWithThreeComponents | 100000      | 7.266 ms | 0.1554 ms | 0.4507 ms | 7.222 ms | 2000.0000 | 2000.0000 | 1000.0000 | 10.22 MB  |
| CreateEntityWithTwoComponents   | 100000      | 7.689 ms | 0.1526 ms | 0.4355 ms | 7.596 ms | 1000.0000 | 1000.0000 | 1000.0000 | 9.22 MB   |

### SystemWithOneComponent:

| Method          | EntityCount | EntityPadding | Mean      | Error    | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |----------:|---------:|---------:|-------:|----------:|
| Sia_MonoThread  | 100000      | 0             | 125.45 us | 2.448 us | 2.405 us |      - |         - |
| Sia_MultiThread | 100000      | 0             |  54.48 us | 0.796 us | 0.744 us | 0.1831 |    1287 B |
| Sia_MonoThread  | 100000      | 10            | 128.31 us | 2.529 us | 4.933 us |      - |         - |
| Sia_MultiThread | 100000      | 10            |  53.83 us | 0.400 us | 0.312 us | 0.1831 |    1303 B |

### SystemWithTwoComponents

| Method          | EntityCount | EntityPadding | Mean      | Error    | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |----------:|---------:|---------:|-------:|----------:|
| Sia_MonoThread  | 100000      | 0             | 154.78 us | 3.033 us | 4.811 us |      - |         - |
| Sia_MultiThread | 100000      | 0             |  60.18 us | 0.856 us | 0.801 us | 0.1221 |    1258 B |
| Sia_MonoThread  | 100000      | 10            | 152.41 us | 2.703 us | 4.287 us |      - |         - |
| Sia_MultiThread | 100000      | 10            |  61.18 us | 1.195 us | 1.861 us | 0.1221 |    1250 B |

### SystemWithThreeComponents:

| Method          | EntityCount | EntityPadding | Mean      | Error    | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |----------:|---------:|---------:|-------:|----------:|
| Sia_MonoThread  | 100000      | 0             | 179.31 us | 2.694 us | 2.520 us |      - |         - |
| Sia_MultiThread | 100000      | 0             |  66.56 us | 0.893 us | 0.835 us | 0.1221 |    1260 B |
| Sia_MonoThread  | 100000      | 10            | 184.87 us | 3.464 us | 3.071 us |      - |         - |
| Sia_MultiThread | 100000      | 10            |  68.43 us | 1.289 us | 1.676 us | 0.1221 |    1256 B |
